### PR TITLE
Update DEP_CXX to use CXX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PREFIX  ?= /usr/local
 
 CXX      ?= g++
 LD       ?= g++
-DEP_CXX  ?= g++
+DEP_CXX  ?= $(CXX)
 AR       ?= ar
 RANLIB   ?= ranlib
 STRIP    ?= strip


### PR DESCRIPTION
Since DEP_CXX is a non standard variable, set it to use CXX to avoid build failures when compiling with clang environments.